### PR TITLE
Add air support and etc.

### DIFF
--- a/init.lua
+++ b/init.lua
@@ -15,7 +15,7 @@ minetest.register_lbm({                            -- this is to remove old brig
 
 nautilus={}
 nautilus.gravity = tonumber(minetest.settings:get("movement_gravity")) or 9.8
-nautilus.fuel = {['biofuel:biofuel'] = 1,['biofuel:bottle_fuel'] = 1,['biofuel:phial_fuel'] = 0.25, ['biofuel:fuel_can'] = 10}
+nautilus.fuel = {['biofuel:biofuel'] = {amount=1},['biofuel:bottle_fuel'] = {amount=1},['biofuel:phial_fuel'] = {amount=0.25}, ['biofuel:fuel_can'] = {amount=10}}
 
 nautilus.colors ={
     black='#2b2b2b',

--- a/init.lua
+++ b/init.lua
@@ -224,7 +224,7 @@ minetest.register_entity("nautilus:boat", {
 
         local pointer=minetest.add_entity(pos,'nautilus:pointer')
         local energy_indicator_angle = nautilus.get_pointer_angle(self.energy)
-        pointer:set_attach(self.object,'',{x=0,y=-8.45,z=5.31},{x=0,y=0,z=energy_indicator_angle})
+        pointer:set_attach(self.object,'',nautilus.GAUGE_FUEL_POSITION,{x=0,y=0,z=energy_indicator_angle})
         self.pointer = pointer
 
         self.object:set_armor_groups({immortal=1})
@@ -333,11 +333,11 @@ minetest.register_entity("nautilus:boat", {
 
             local energy_indicator_angle = nautilus.get_pointer_angle(self.energy)
             if self.pointer:get_luaentity() then
-                self.pointer:set_attach(self.object,'',{x=0,y=-8.45,z=5.31},{x=0,y=0,z=energy_indicator_angle})
+                self.pointer:set_attach(self.object,'',nautilus.GAUGE_FUEL_POSITION,{x=0,y=0,z=energy_indicator_angle})
             else
                 --in case it have lost the entity by some conflict
-                self.pointer=minetest.add_entity({x=0,y=-8.45,z=5.31},'nautilus:pointer')
-                self.pointer:set_attach(self.object,'',{x=0,y=-8.45,z=5.31},{x=0,y=0,z=energy_indicator_angle})
+                self.pointer=minetest.add_entity(nautilus.GAUGE_FUEL_POSITION,'nautilus:pointer')
+                self.pointer:set_attach(self.object,'',nautilus.GAUGE_FUEL_POSITION,{x=0,y=0,z=energy_indicator_angle})
             end
         end
         if self.energy <= 0 then
@@ -412,7 +412,7 @@ minetest.register_entity("nautilus:boat", {
 
         if is_attached == true then
             --refuel
-            nautilus_load_fuel(self, puncher:get_player_name())
+            nautilus.load_fuel(self, puncher:get_player_name())
             self.engine_running = true
         end
 

--- a/init.lua
+++ b/init.lua
@@ -223,7 +223,7 @@ minetest.register_entity("nautilus:boat", {
         self.object:set_animation({x = 1, y = 5}, 0, 0, true);
 
         local pointer=minetest.add_entity(pos,'nautilus:pointer')
-        local energy_indicator_angle = nautilus.get_pointer_angle(self.energy)
+        local energy_indicator_angle = nautilus.get_pointer_angle(self.energy, nautilus.MAX_FUEL)
         pointer:set_attach(self.object,'',nautilus.GAUGE_FUEL_POSITION,{x=0,y=0,z=energy_indicator_angle})
         self.pointer = pointer
 
@@ -328,10 +328,10 @@ minetest.register_entity("nautilus:boat", {
         if self.energy > 0 then
             local zero_reference = vector.new()
             local acceleration = nautilus.get_hipotenuse_value(accel, zero_reference)
-            local consumed_power = acceleration/6000
+            local consumed_power = acceleration/nautilus.FUEL_CONSUMPTION
             self.energy = self.energy - consumed_power;
 
-            local energy_indicator_angle = nautilus.get_pointer_angle(self.energy)
+            local energy_indicator_angle = nautilus.get_pointer_angle(self.energy, nautilus.MAX_FUEL)
             if self.pointer:get_luaentity() then
                 self.pointer:set_attach(self.object,'',nautilus.GAUGE_FUEL_POSITION,{x=0,y=0,z=energy_indicator_angle})
             else

--- a/init.lua
+++ b/init.lua
@@ -179,7 +179,7 @@ local function open_cover(self, player)
         if (node_def.liquidtype=="none") and (node_def.drowning==0) then
             if (self.air < nautilus.REAIR_ON_AIR) then
                 self.air = nautilus.REAIR_ON_AIR
-                minetest.chat_send_player(player:get_player_name(), "Submarine has been filled by fresh air.")
+                minetest.chat_send_player(player:get_player_name(), "Nautilus has been filled with fresh air.")
             end
         else
             self.air = self.air - nautilus.OPEN_AIR_LOST
@@ -739,7 +739,23 @@ minetest.register_craftitem("nautilus:boat", {
         local node_below = minetest.get_node(pointed_pos).name
         local nodedef = minetest.registered_nodes[node_below]
         if nodedef.liquidtype ~= "none" then
-            pointed_pos.y=pointed_pos.y+0.2
+            -- minimum water depth has to be 2, for place submarine
+            pointed_pos.y = pointed_pos.y - 1;
+            node_below = minetest.get_node(pointed_pos).name
+            nodedef = minetest.registered_nodes[node_below]
+            if nodedef.liquidtype == "none" then
+                minetest.chat_send_player(placer:get_player_name(), "Nautilus have to be placed on deeper water.")
+                return
+            end
+            -- submarine can be placed only on water surface
+            pointed_pos.y = pointed_pos.y + 2;
+            node_below = minetest.get_node(pointed_pos).name
+            nodedef = minetest.registered_nodes[node_below]
+            if (nodedef.liquidtype ~= "none") or (nodedef.buildable_to==false) then
+                minetest.chat_send_player(placer:get_player_name(), "Nautilus have to be placed on open water surface")
+                return
+            end
+            pointed_pos.y = pointed_pos.y + 1.2
             local boat = minetest.add_entity(pointed_pos, "nautilus:boat")
             if boat and placer then
                 local ent = boat:get_luaentity()

--- a/init.lua
+++ b/init.lua
@@ -5,13 +5,13 @@ local LONGIT_DRAG_FACTOR = 0.13*0.13
 local LATER_DRAG_FACTOR = 2.0
 
 minetest.register_lbm({                            -- this is to remove old bright water nodes after server crash etc
-	name = "nautilus:delete_lights",
-	run_at_every_load = true,
-		nodenames = {"nautilus:water_light"},
-		action = function(pos, node)
-				minetest.set_node(pos, {name = "default:water_source"})
-		end,
-	})
+    name = "nautilus:delete_lights",
+    run_at_every_load = true,
+        nodenames = {"nautilus:water_light"},
+        action = function(pos, node)
+                minetest.set_node(pos, {name = "default:water_source"})
+        end,
+    })
 
 nautilus={}
 nautilus.gravity = tonumber(minetest.settings:get("movement_gravity")) or 9.8
@@ -36,12 +36,12 @@ nautilus.colors ={
 }
 
 function nautilus.clone_node(node_name)
-	if not (node_name and type(node_name) == 'string') then
-		return
-	end
+    if not (node_name and type(node_name) == 'string') then
+        return
+    end
 
-	local node = minetest.registered_nodes[node_name]
-	return table.copy(node)
+    local node = minetest.registered_nodes[node_name]
+    return table.copy(node)
 end
 
 dofile(minetest.get_modpath("nautilus") .. DIR_DELIM .. "nautilus_control.lua")
@@ -60,15 +60,15 @@ function nautilus.get_hipotenuse_value(point1, point2)
 end
 
 function nautilus.dot(v1,v2)
-	return v1.x*v2.x+v1.y*v2.y+v1.z*v2.z
+    return v1.x*v2.x+v1.y*v2.y+v1.z*v2.z
 end
 
 function nautilus.sign(n)
-	return n>=0 and 1 or -1
+    return n>=0 and 1 or -1
 end
 
 function nautilus.minmax(v,m)
-	return math.min(math.abs(v),m)*nautilus.sign(v)
+    return math.min(math.abs(v),m)*nautilus.sign(v)
 end
 
 -- lets control particle emission frequency
@@ -85,7 +85,7 @@ function nautilus.paint(self, colstr)
                 l_textures[_] = "nautilus_painting.png^[multiply:".. colstr
             end
         end
-	    self.object:set_properties({textures=l_textures})
+        self.object:set_properties({textures=l_textures})
     end
 end
 
@@ -113,11 +113,11 @@ function nautilus.destroy(self)
 
     pos.y=pos.y+2
     --[[for i=1,7 do
-	    minetest.add_item({x=pos.x+math.random()-0.5,y=pos.y,z=pos.z+math.random()-0.5},'default:steel_ingot')
+        minetest.add_item({x=pos.x+math.random()-0.5,y=pos.y,z=pos.z+math.random()-0.5},'default:steel_ingot')
     end
 
     for i=1,7 do
-	    minetest.add_item({x=pos.x+math.random()-0.5,y=pos.y,z=pos.z+math.random()-0.5},'default:mese_crystal')
+        minetest.add_item({x=pos.x+math.random()-0.5,y=pos.y,z=pos.z+math.random()-0.5},'default:mese_crystal')
     end]]--
 
     minetest.add_item({x=pos.x+math.random()-0.5,y=pos.y,z=pos.z+math.random()-0.5},'nautilus:boat')
@@ -149,7 +149,7 @@ function nautilus.attach(self, player)
     minetest.after(0.2, function()
         local player = minetest.get_player_by_name(name)
         if player then
-	        player_api.set_animation(player, "sit")
+            player_api.set_animation(player, "sit")
         end
     end)
     -- disable gravity
@@ -161,17 +161,17 @@ end
 --
 
 minetest.register_entity("nautilus:boat", {
-	initial_properties = {
-	    physical = true,
-	    collisionbox = {-1, -1, -1, 1, 1, 1}, --{-1,0,-1, 1,0.3,1},
-	    selectionbox = {-0.6,0.6,-0.6, 0.6,1,0.6},
-	    visual = "mesh",
-	    mesh = "nautilus.b3d",
+    initial_properties = {
+        physical = true,
+        collisionbox = {-1, -1, -1, 1, 1, 1}, --{-1,0,-1, 1,0.3,1},
+        selectionbox = {-0.6,0.6,-0.6, 0.6,1,0.6},
+        visual = "mesh",
+        mesh = "nautilus.b3d",
         textures = {"nautilus_black.png", "nautilus_painting.png", "nautilus_glass.png", "nautilus_metal.png", "nautilus_metal.png", "nautilus_orange.png", "nautilus_painting.png", "nautilus_red.png", "nautilus_painting.png", "nautilus_helice.png", "nautilus_interior.png", "nautilus_panel.png"},
     },
     textures = {},
-	driver_name = nil,
-	sound_handle = nil,
+    driver_name = nil,
+    sound_handle = nil,
     energy = 0.001,
     owner = "",
     static_save = true,
@@ -200,7 +200,7 @@ minetest.register_entity("nautilus:boat", {
         })
     end,
 
-	on_activate = function(self, staticdata, dtime_s)
+    on_activate = function(self, staticdata, dtime_s)
         if staticdata ~= "" and staticdata ~= nil then
             local data = minetest.deserialize(staticdata) or {}
             self.energy = data.stored_energy
@@ -222,37 +222,37 @@ minetest.register_entity("nautilus:boat", {
         --animation load - stoped
         self.object:set_animation({x = 1, y = 5}, 0, 0, true);
 
-	    local pointer=minetest.add_entity(pos,'nautilus:pointer')
+        local pointer=minetest.add_entity(pos,'nautilus:pointer')
         local energy_indicator_angle = nautilus.get_pointer_angle(self.energy)
-	    pointer:set_attach(self.object,'',{x=0,y=-8.45,z=5.31},{x=0,y=0,z=energy_indicator_angle})
-	    self.pointer = pointer
+        pointer:set_attach(self.object,'',{x=0,y=-8.45,z=5.31},{x=0,y=0,z=energy_indicator_angle})
+        self.pointer = pointer
 
-		self.object:set_armor_groups({immortal=1})
+        self.object:set_armor_groups({immortal=1})
 
         mobkit.actfunc(self, staticdata, dtime_s)
 
-	end,
+    end,
 
-	on_step = function(self, dtime)
+    on_step = function(self, dtime)
         mobkit.stepfunc(self, dtime)
         
         local accel_y = self.object:get_acceleration().y
         local rotation = self.object:get_rotation()
         local yaw = rotation.y
-		local newyaw=yaw
+        local newyaw=yaw
         local pitch = rotation.x
         local newpitch = pitch
-		local roll = rotation.z
-		local newroll=roll
+        local roll = rotation.z
+        local newroll=roll
 
         local hull_direction = minetest.yaw_to_dir(yaw)
-        local nhdir = {x=hull_direction.z,y=0,z=-hull_direction.x}		-- lateral unit vector
+        local nhdir = {x=hull_direction.z,y=0,z=-hull_direction.x}        -- lateral unit vector
         local velocity = self.object:get_velocity()
 
         local longit_speed = nautilus.dot(velocity,hull_direction)
         local longit_drag = vector.multiply(hull_direction,longit_speed*longit_speed*LONGIT_DRAG_FACTOR*-1*nautilus.sign(longit_speed))
-		local later_speed = nautilus.dot(velocity,nhdir)
-		local later_drag = vector.multiply(nhdir,later_speed*later_speed*LATER_DRAG_FACTOR*-1*nautilus.sign(later_speed))
+        local later_speed = nautilus.dot(velocity,nhdir)
+        local later_drag = vector.multiply(nhdir,later_speed*later_speed*LATER_DRAG_FACTOR*-1*nautilus.sign(later_speed))
         local accel = vector.add(longit_drag,later_drag)
 
         local vel = self.object:get_velocity()
@@ -269,16 +269,16 @@ minetest.register_entity("nautilus:boat", {
             end
         end
 
-		if is_attached then
+        if is_attached then
             local impact = nautilus.get_hipotenuse_value(vel, self.last_vel)
             if impact > 1 then
                 --self.damage = self.damage + impact --sum the impact value directly to damage meter
                 local curr_pos = self.object:get_pos()
                 minetest.sound_play("collision", {
                     to_player = self.driver_name,
-	                --pos = curr_pos,
-	                --max_hear_distance = 5,
-	                gain = 1.0,
+                    --pos = curr_pos,
+                    --max_hear_distance = 5,
+                    gain = 1.0,
                     fade = 0.0,
                     pitch = 1.0,
                 })
@@ -291,7 +291,7 @@ minetest.register_entity("nautilus:boat", {
                 player:set_breath(10)
             end
             --control
-			accel = nautilus.nautilus_control(self, dtime, hull_direction, longit_speed, accel) or vel
+            accel = nautilus.nautilus_control(self, dtime, hull_direction, longit_speed, accel) or vel
 
             --light
             --local pos = obj:get_pos()
@@ -312,16 +312,16 @@ minetest.register_entity("nautilus:boat", {
             if can_stop then
                 --detach player
                 if self.sound_handle ~= nil then
-	                minetest.sound_stop(self.sound_handle)
-	                self.sound_handle = nil
+                    minetest.sound_stop(self.sound_handle)
+                    self.sound_handle = nil
                 end
             end
-		end
+        end
 
-		if math.abs(self.rudder_angle)>5 then 
+        if math.abs(self.rudder_angle)>5 then 
             local turn_rate = math.rad(24)
-			newyaw = yaw + self.dtime*(1 - 1 / (math.abs(longit_speed) + 1)) * self.rudder_angle / 30 * turn_rate * nautilus.sign(longit_speed)
-		end
+            newyaw = yaw + self.dtime*(1 - 1 / (math.abs(longit_speed) + 1)) * self.rudder_angle / 30 * turn_rate * nautilus.sign(longit_speed)
+        end
 
         -- calculate energy consumption --
         ----------------------------------
@@ -343,31 +343,31 @@ minetest.register_entity("nautilus:boat", {
         if self.energy <= 0 then
             self.engine_running = false
             if self.sound_handle then minetest.sound_stop(self.sound_handle) end
-		    self.object:set_animation_frame_speed(0)
+            self.object:set_animation_frame_speed(0)
         end
         ----------------------------
         -- end energy consumption --
 
         --roll adjust
         ---------------------------------
-		local sdir = minetest.yaw_to_dir(newyaw)
-		local snormal = {x=sdir.z,y=0,z=-sdir.x}	-- rightside, dot is negative
-		local prsr = nautilus.dot(snormal,nhdir)
+        local sdir = minetest.yaw_to_dir(newyaw)
+        local snormal = {x=sdir.z,y=0,z=-sdir.x}    -- rightside, dot is negative
+        local prsr = nautilus.dot(snormal,nhdir)
         local rollfactor = -10
         newroll = (prsr*math.rad(rollfactor))*later_speed
         --minetest.chat_send_all('newroll: '.. newroll)
         ---------------------------------
         -- end roll
 
-		--local bob = nautilus.minmax(nautilus.dot(accel,hull_direction),0.8)	-- vertical bobbing
+        --local bob = nautilus.minmax(nautilus.dot(accel,hull_direction),0.8)    -- vertical bobbing
 
-		if self.isinliquid then
-			accel.y = accel_y -- + bob
-			newpitch = velocity.y * math.rad(6)
-			self.object:set_acceleration(accel)
-		end
+        if self.isinliquid then
+            accel.y = accel_y -- + bob
+            newpitch = velocity.y * math.rad(6)
+            self.object:set_acceleration(accel)
+        end
 
-		if newyaw~=yaw or newpitch~=pitch or newroll~=roll then
+        if newyaw~=yaw or newpitch~=pitch or newroll~=roll then
             self.object:set_rotation({x=newpitch,y=newyaw,z=newroll})
         end
 
@@ -382,22 +382,22 @@ minetest.register_entity("nautilus:boat", {
 
         --saves last velocy for collision detection (abrupt stop)
         self.last_vel = self.object:get_velocity()
-	end,
+    end,
 
-	on_punch = function(self, puncher, ttime, toolcaps, dir, damage)
-		if not puncher or not puncher:is_player() then
-			return
-		end
-		local name = puncher:get_player_name()
+    on_punch = function(self, puncher, ttime, toolcaps, dir, damage)
+        if not puncher or not puncher:is_player() then
+            return
+        end
+        local name = puncher:get_player_name()
         if self.owner and self.owner ~= name and self.owner ~= "" then return end
         if self.owner == nil then
             self.owner = name
         end
-        	
+            
         if self.driver_name and self.driver_name ~= name then
-			-- do not allow other players to remove the object while there is a driver
-			return
-		end
+            -- do not allow other players to remove the object while there is a driver
+            return
+        end
 
         local touching_ground, liquid_below = nautilus.check_node_below(self.object)
         
@@ -419,35 +419,35 @@ minetest.register_entity("nautilus:boat", {
         if is_attached == false then
 
             -- deal with painting or destroying
-		    if itmstck then
-			    local _,indx = item_name:find('dye:')
-			    if indx then
+            if itmstck then
+                local _,indx = item_name:find('dye:')
+                if indx then
 
                     --lets paint!!!!
-				    local color = item_name:sub(indx+1)
-				    local colstr = nautilus.colors[color]
+                    local color = item_name:sub(indx+1)
+                    local colstr = nautilus.colors[color]
                     --minetest.chat_send_all(color ..' '.. dump(colstr))
-				    if colstr then
+                    if colstr then
                         nautilus.paint(self, colstr)
-					    itmstck:set_count(itmstck:get_count()-1)
-					    puncher:set_wielded_item(itmstck)
-				    end
+                        itmstck:set_count(itmstck:get_count()-1)
+                        puncher:set_wielded_item(itmstck)
+                    end
                     -- end painting
 
-			    else -- deal damage
-				    if not self.driver and toolcaps and toolcaps.damage_groups and toolcaps.damage_groups.fleshy then
-					    --mobkit.hurt(self,toolcaps.damage_groups.fleshy - 1)
-					    --mobkit.make_sound(self,'hit')
+                else -- deal damage
+                    if not self.driver and toolcaps and toolcaps.damage_groups and toolcaps.damage_groups.fleshy then
+                        --mobkit.hurt(self,toolcaps.damage_groups.fleshy - 1)
+                        --mobkit.make_sound(self,'hit')
                         self.hp = self.hp - 10
                         minetest.sound_play("collision", {
-	                        object = self.object,
-	                        max_hear_distance = 5,
-	                        gain = 1.0,
+                            object = self.object,
+                            max_hear_distance = 5,
+                            gain = 1.0,
                             fade = 0.0,
                             pitch = 1.0,
                         })
-				    end
-			    end
+                    end
+                end
             end
 
             if self.hp <= 0 then
@@ -456,47 +456,47 @@ minetest.register_entity("nautilus:boat", {
 
         end
         
-	end,
+    end,
 
-	on_rightclick = function(self, clicker)
-		if not clicker or not clicker:is_player() then
-			return
-		end
+    on_rightclick = function(self, clicker)
+        if not clicker or not clicker:is_player() then
+            return
+        end
 
-		local name = clicker:get_player_name()
+        local name = clicker:get_player_name()
         if self.owner and self.owner ~= name and self.owner ~= "" then return end
         if self.owner == "" then
             self.owner = name
         end
 
-		if name == self.driver_name then
+        if name == self.driver_name then
             self.engine_running = false
 
-			-- driver clicked the object => driver gets off the vehicle
+            -- driver clicked the object => driver gets off the vehicle
             --self.object:set_properties({glow = 0})
-			self.driver_name = nil
+            self.driver_name = nil
             clicker:set_breath(10)
-			-- sound and animation
+            -- sound and animation
             if self.sound_handle then
                 minetest.sound_stop(self.sound_handle)
                 self.sound_handle = nil
             end
-			
-			--self.engine:set_animation_frame_speed(0)
+            
+            --self.engine:set_animation_frame_speed(0)
 
             -- detach the player
-		    clicker:set_detach()
-		    player_api.player_attached[name] = nil
-		    clicker:set_eye_offset({x=0,y=0,z=0},{x=0,y=0,z=0})
-		    player_api.set_animation(clicker, "stand")
-		    self.driver = nil
+            clicker:set_detach()
+            player_api.player_attached[name] = nil
+            clicker:set_eye_offset({x=0,y=0,z=0},{x=0,y=0,z=0})
+            player_api.set_animation(clicker, "stand")
+            self.driver = nil
             --self.object:set_acceleration(vector.multiply(nautilus.vector_up, -nautilus.gravity))
         
-		elseif not self.driver_name then
+        elseif not self.driver_name then
             -- no driver => clicker is new driver
             nautilus.attach(self, clicker)
-		end
-	end,
+        end
+    end,
 })
 
 -----------
@@ -504,49 +504,49 @@ minetest.register_entity("nautilus:boat", {
 -----------
 
 function nautilus.put_light(object, name)
-	local pos = object:getpos()
-	if not pos then
-		return
-	end
+    local pos = object:getpos()
+    if not pos then
+        return
+    end
 
     local player = minetest.get_player_by_name(name)
     local dir = player:get_look_dir()
     pos = nautilus.find_collision(pos,dir)
 
     if pos then
-	    local n = minetest.get_node_or_nil(pos)
+        local n = minetest.get_node_or_nil(pos)
         --minetest.chat_send_player(name, n.name)
         if n and n.name == 'default:water_source' then
-		    minetest.set_node(pos, {name='nautilus:water_light'})
-		    --local timer = minetest.get_node_timer(pos)
-		    --timer:set(10, 0)
+            minetest.set_node(pos, {name='nautilus:water_light'})
+            --local timer = minetest.get_node_timer(pos)
+            --timer:set(10, 0)
             minetest.after(10,function(pos)
-			    local node = minetest.get_node_or_nil(pos)
-			    if node and node.name == "nautilus:water_light" then
-				    minetest.swap_node(pos, {name="default:water_source"})
-			    end
-			end, pos)
-	    end
+                local node = minetest.get_node_or_nil(pos)
+                if node and node.name == "nautilus:water_light" then
+                    minetest.swap_node(pos, {name="default:water_source"})
+                end
+            end, pos)
+        end
     end
 
-	--[[
+    --[[
     local r = 6
     local count = 0
-	for _ = 1, 3 do
-		local fpos = {}
-		fpos.x = pos.x + math.random(2 * r + 1) - r - 1
-		fpos.y = pos.y + math.random(2 * r + 1) - r - 1
-		fpos.z = pos.z + math.random(2 * r + 1) - r - 1
-		local n = minetest.get_node_or_nil(fpos)
+    for _ = 1, 3 do
+        local fpos = {}
+        fpos.x = pos.x + math.random(2 * r + 1) - r - 1
+        fpos.y = pos.y + math.random(2 * r + 1) - r - 1
+        fpos.z = pos.z + math.random(2 * r + 1) - r - 1
+        local n = minetest.get_node_or_nil(fpos)
         if n and n.name == 'default:water_source' then
-			minetest.set_node(fpos, {name='nautilus:water_light'})
-			local timer = minetest.get_node_timer(fpos)
-			timer:set(10, 0)
-			count = count + 1
-		end
-	end
+            minetest.set_node(fpos, {name='nautilus:water_light'})
+            local timer = minetest.get_node_timer(fpos)
+            timer:set(10, 0)
+            count = count + 1
+        end
+    end
 
-	return count]]--
+    return count]]--
 end
 
 
@@ -555,29 +555,29 @@ nautilus_newnode.light_source = 14
 nautilus_newnode.liquid_alternative_flowing = 'nautilus:water_light'
 nautilus_newnode.liquid_alternative_source = 'nautilus:water_light'
 nautilus_newnode.on_timer = function(pos)
-	minetest.remove_node(pos)
+    minetest.remove_node(pos)
 end
 minetest.register_node('nautilus:water_light', nautilus_newnode)
 
 -- [[ from Gundul mod lightup ]]--
 function nautilus.find_collision(pos1,dir)
-	pos1 = mobkit.pos_shift(pos1,vector.multiply(dir,1))
+    pos1 = mobkit.pos_shift(pos1,vector.multiply(dir,1))
     local distance = 20
-	local pos2 = mobkit.pos_shift(pos1,vector.multiply(dir,distance))
-	local ray = minetest.raycast(pos1, pos2, true, false)
-			for pointed_thing in ray do
-				if pointed_thing.type == "node" then
-					local dist = math.floor(vector.distance(pos1,pointed_thing.under))
-					pos2 = mobkit.pos_shift(pos1,vector.multiply(dir,dist-1))
-					return pos2
-				end
-				if pointed_thing.type == "object" then
-					local obj = pointed_thing.ref
-					local objpos = obj:get_pos()
-					return objpos
-				end
-			end
-	return nil
+    local pos2 = mobkit.pos_shift(pos1,vector.multiply(dir,distance))
+    local ray = minetest.raycast(pos1, pos2, true, false)
+            for pointed_thing in ray do
+                if pointed_thing.type == "node" then
+                    local dist = math.floor(vector.distance(pos1,pointed_thing.under))
+                    pos2 = mobkit.pos_shift(pos1,vector.multiply(dir,dist-1))
+                    return pos2
+                end
+                if pointed_thing.type == "object" then
+                    local obj = pointed_thing.ref
+                    local objpos = obj:get_pos()
+                    return objpos
+                end
+            end
+    return nil
 end
 
 -----------
@@ -586,47 +586,47 @@ end
 
 -- blades
 minetest.register_craftitem("nautilus:engine",{
-	description = "Nautilus Engine",
-	inventory_image = "nautilus_icon_engine.png",
+    description = "Nautilus Engine",
+    inventory_image = "nautilus_icon_engine.png",
 })
 -- cabin
 minetest.register_craftitem("nautilus:cabin",{
-	description = "Cabin for Nautilus",
-	inventory_image = "nautilus_icon_cabin.png",
+    description = "Cabin for Nautilus",
+    inventory_image = "nautilus_icon_cabin.png",
 })
 
 -- boat
 minetest.register_craftitem("nautilus:boat", {
-	description = "Nautilus",
-	inventory_image = "nautilus_icon.png",
+    description = "Nautilus",
+    inventory_image = "nautilus_icon.png",
     liquids_pointable = true,
 
-	on_place = function(itemstack, placer, pointed_thing)
-		if pointed_thing.type ~= "node" then
-			return
-		end
+    on_place = function(itemstack, placer, pointed_thing)
+        if pointed_thing.type ~= "node" then
+            return
+        end
         
         local pointed_pos = pointed_thing.under
         local node_below = minetest.get_node(pointed_pos).name
         local nodedef = minetest.registered_nodes[node_below]
         if nodedef.liquidtype ~= "none" then
-			pointed_pos.y=pointed_pos.y+0.2
-			local boat = minetest.add_entity(pointed_pos, "nautilus:boat")
-			if boat and placer then
+            pointed_pos.y=pointed_pos.y+0.2
+            local boat = minetest.add_entity(pointed_pos, "nautilus:boat")
+            if boat and placer then
                 local ent = boat:get_luaentity()
                 local owner = placer:get_player_name()
                 ent.owner = owner
-				boat:set_yaw(placer:get_look_horizontal())
-				itemstack:take_item()
+                boat:set_yaw(placer:get_look_horizontal())
+                itemstack:take_item()
 
                 local properties = ent.object:get_properties()
                 properties.infotext = owner .. " nice submarine"
                 ent.object:set_properties(properties)
-			end
+            end
         end
 
-		return itemstack
-	end,
+        return itemstack
+    end,
 })
 
 --
@@ -634,29 +634,29 @@ minetest.register_craftitem("nautilus:boat", {
 --
 
 if minetest.get_modpath("default") then
-	minetest.register_craft({
-		output = "nautilus:boat",
-		recipe = {
-			{"",                "",               ""},
-			{"nautilus:engine", "nautilus:cabin", "nautilus:engine"},
-		}
-	})
-	minetest.register_craft({
-		output = "nautilus:engine",
-		recipe = {
-			{"",                    "default:steel_ingot", ""},
-			{"default:steel_ingot", "default:mese_crystal",  "default:steel_ingot"},
-			{"",                    "default:steel_ingot", "default:diamond"},
-		}
-	})
-	minetest.register_craft({
-		output = "nautilus:cabin",
-		recipe = {
-			{"default:steel_ingot", "default:steelblock", "default:steel_ingot"},
-			{"default:steelblock",  "default:glass",      "default:steelblock"},
-			{"default:steel_ingot", "default:steelblock", "default:steel_ingot"},
-		}
-	})
+    minetest.register_craft({
+        output = "nautilus:boat",
+        recipe = {
+            {"",                "",               ""},
+            {"nautilus:engine", "nautilus:cabin", "nautilus:engine"},
+        }
+    })
+    minetest.register_craft({
+        output = "nautilus:engine",
+        recipe = {
+            {"",                    "default:steel_ingot", ""},
+            {"default:steel_ingot", "default:mese_crystal",  "default:steel_ingot"},
+            {"",                    "default:steel_ingot", "default:diamond"},
+        }
+    })
+    minetest.register_craft({
+        output = "nautilus:cabin",
+        recipe = {
+            {"default:steel_ingot", "default:steelblock", "default:steel_ingot"},
+            {"default:steelblock",  "default:glass",      "default:steelblock"},
+            {"default:steel_ingot", "default:steelblock", "default:steel_ingot"},
+        }
+    })
 end
 
 

--- a/mod.conf
+++ b/mod.conf
@@ -1,5 +1,5 @@
 name = nautilus
-depends = mobkit,default,biofuel
+depends = mobkit,default,player_api,biofuel
 optional_depends = vacuum
 author = APercy
 description = Adds a craftable submarine

--- a/mod.conf
+++ b/mod.conf
@@ -1,5 +1,6 @@
 name = nautilus
 depends = mobkit,default,biofuel
+optional_depends = vacuum
 author = APercy
 description = Adds a craftable submarine
 title = Nautilus

--- a/nautilus_air_management.lua
+++ b/nautilus_air_management.lua
@@ -3,6 +3,8 @@
 --
 nautilus.GAUGE_AIR_POSITION = {x=0,y=-8.45,z=5.31}
 nautilus.MAX_AIR = minetest.settings:get("nautilus_max_air") or 1200
+nautilus.REAIR_ON_AIR = minetest.settings:get("nautilus_reair_on_air") or 200
+nautilus.OPEN_AIR_LOST = minetest.settings:get("nautilus_open_air_lost") or 20
 
 minetest.register_entity('nautilus:pointer_air',{
 initial_properties = {

--- a/nautilus_air_management.lua
+++ b/nautilus_air_management.lua
@@ -1,0 +1,68 @@
+--
+-- air
+--
+nautilus.GAUGE_AIR_POSITION = {x=0,y=-8.45,z=5.31}
+nautilus.MAX_AIR = minetest.settings:get("nautilus_max_air") or 1200
+
+minetest.register_entity('nautilus:pointer_air',{
+initial_properties = {
+	physical = false,
+	collide_with_objects=false,
+	pointable=false,
+	visual = "mesh",
+	mesh = "pointer.b3d",
+	textures = {"nautilus_interior.png^[multiply:#0000FF"},
+	},
+	
+on_activate = function(self,std)
+	self.sdata = minetest.deserialize(std) or {}
+	if self.sdata.remove then self.object:remove() end
+end,
+	
+get_staticdata=function(self)
+  	
+  self.sdata.remove=true
+  return minetest.serialize(self.sdata)
+end,
+	
+})
+
+-- definedin fuel magament file
+--function nautilus.contains(table, val)
+
+function nautilus.load_air(self, player_name)
+    local player = minetest.get_player_by_name(player_name)
+    local inv = player:get_inventory()
+
+    local itmstck=player:get_wielded_item()
+    local item_name = ""
+    if itmstck then item_name = itmstck:get_name() end
+
+    local stack = nil
+    --minetest.debug("air: ", item_name)
+    local air = nautilus.contains(nautilus.air, item_name)
+    if air then
+        stack = ItemStack(item_name .. " 1")
+        
+        if self.air < nautilus.MAX_AIR then
+            local taken = inv:remove_item("main", stack)
+            self.air = self.air + air.amount
+            if self.air > nautilus.MAX_AIR then self.air = nautilus.MAX_AIR end
+            
+            if air.drop then
+                local leftover = inv:add_item("main", air.drop)
+                if leftover then
+                    minetest.item_drop(leftover, player, player:get_pos())
+                end
+            end
+
+            local air_indicator_angle = nautilus.get_pointer_angle(self.air, nautilus.MAX_AIR)
+            self.pointer:set_attach(self.object,'',nautilus.GAUGE_AIR_POSITION,{x=0,y=0,z=air_indicator_angle})
+        end
+        
+        return true
+    end
+
+    return false
+end
+

--- a/nautilus_control.lua
+++ b/nautilus_control.lua
@@ -3,11 +3,11 @@
 nautilus.nautilus_last_time_command = 0
 nautilus.vector_up = vector.new(0, 1, 0)
 
-function nautilus.get_pointer_angle(energy)
-    local angle = energy * 18
+function nautilus.get_pointer_angle(value, maxvalue)
+    local angle = value/maxvalue * 180
     angle = angle - 90
     angle = angle * -1
-	return angle
+    return angle
 end
 
 function nautilus.check_node_below(obj)

--- a/nautilus_fuel_management.lua
+++ b/nautilus_fuel_management.lua
@@ -53,8 +53,15 @@ function nautilus.load_fuel(self, player_name)
 
         if self.energy < nautilus.MAX_FUEL then
             local taken = inv:remove_item("main", stack)
-            self.energy = self.energy + fuel
+            self.energy = self.energy + fuel.amount
             if self.energy > nautilus.MAX_FUEL then self.energy = nautilus.MAX_FUEL end
+            
+            if fuel.drop then
+                local leftover = inv:add_item("main", fuel.drop)
+                if leftover then
+                    minetest.item_drop(leftover, player, player:get_pos())
+                end
+            end
 
             local energy_indicator_angle = nautilus.get_pointer_angle(self.energy, nautilus.MAX_FUEL)
             self.pointer:set_attach(self.object,'',nautilus.GAUGE_FUEL_POSITION,{x=0,y=0,z=energy_indicator_angle})

--- a/nautilus_fuel_management.lua
+++ b/nautilus_fuel_management.lua
@@ -2,6 +2,8 @@
 -- fuel
 --
 nautilus.GAUGE_FUEL_POSITION = {x=0,y=-8.45,z=5.31}
+nautilus.MAX_FUEL = minetest.settings:get("nautilus_max_fuel") or 10
+nautilus.FUEL_CONSUMPTION = minetest.settings:get("nautilus_fuel_consumption") or 6000
 
 minetest.register_entity('nautilus:pointer',{
 initial_properties = {
@@ -49,12 +51,12 @@ function nautilus.load_fuel(self, player_name)
     if fuel then
         stack = ItemStack(item_name .. " 1")
 
-        if self.energy < 10 then
+        if self.energy < nautilus.MAX_FUEL then
             local taken = inv:remove_item("main", stack)
             self.energy = self.energy + fuel
-            if self.energy > 10 then self.energy = 10 end
+            if self.energy > nautilus.MAX_FUEL then self.energy = nautilus.MAX_FUEL end
 
-            local energy_indicator_angle = nautilus.get_pointer_angle(self.energy)
+            local energy_indicator_angle = nautilus.get_pointer_angle(self.energy, nautilus.MAX_FUEL)
             self.pointer:set_attach(self.object,'',nautilus.GAUGE_FUEL_POSITION,{x=0,y=0,z=energy_indicator_angle})
         end
         

--- a/nautilus_fuel_management.lua
+++ b/nautilus_fuel_management.lua
@@ -1,7 +1,7 @@
 --
 -- fuel
 --
-NAUTILUS_GAUGE_FUEL_POSITION = {x=0,y=-8.45,z=5.31}
+nautilus.GAUGE_FUEL_POSITION = {x=0,y=-8.45,z=5.31}
 
 minetest.register_entity('nautilus:pointer',{
 initial_properties = {
@@ -35,7 +35,7 @@ function nautilus.contains(table, val)
     return false
 end
 
-function nautilus_load_fuel(self, player_name)
+function nautilus.load_fuel(self, player_name)
     local player = minetest.get_player_by_name(player_name)
     local inv = player:get_inventory()
 
@@ -55,7 +55,7 @@ function nautilus_load_fuel(self, player_name)
             if self.energy > 10 then self.energy = 10 end
 
             local energy_indicator_angle = nautilus.get_pointer_angle(self.energy)
-            self.pointer:set_attach(self.object,'',NAUTILUS_GAUGE_FUEL_POSITION,{x=0,y=0,z=energy_indicator_angle})
+            self.pointer:set_attach(self.object,'',nautilus.GAUGE_FUEL_POSITION,{x=0,y=0,z=energy_indicator_angle})
         end
         
         return true

--- a/settingtypes.txt
+++ b/settingtypes.txt
@@ -1,0 +1,15 @@
+
+# Fuel capacity of nautilus submarine.
+nautilus_max_fuel (Max fuel units) float 10 1 100
+
+# Nautilus submarine fuel consumption ratio.
+nautilus_fuel_consumption (Fuel consumption ratio) int 6000 1
+
+# Enable/disable limited air in submarine
+# default is enabled if vacuum mode is enabled, othervise disabled
+nautilus_air (Max fuel units) bool true
+
+# Air capacity of nautilus submarine.
+# 1 unit per second is consumed
+nautilus_max_air (Max air units) float 1200 1
+

--- a/settingtypes.txt
+++ b/settingtypes.txt
@@ -13,3 +13,9 @@ nautilus_air (Max fuel units) bool true
 # 1 unit per second is consumed
 nautilus_max_air (Max air units) float 1200 1
 
+# Reair on air when cover is opened
+nautilus_reair_on_air (Reair on open) float 200 1
+
+# Air lost when cover is opened under water
+nautilus_open_air_lost (Lost of air when open) float 10 1
+


### PR DESCRIPTION
- Makes nautilus mod more configurable by settings (the limit for fuel, air, etc).
- Little reformated code (replaces some tabs by spaces).
- Add air support (defaultly available when vacuum mod is enabled)
- Refill submarine with air when cover is open on water surface
- Some air lost when the cover is open underwater.
- Add nautilus place check (cannot be placed on shallow water, have to be placed on the open water surface)
