### PR TITLE
Add preasure limit

### DIFF
--- a/init.lua
+++ b/init.lua
@@ -25,6 +25,7 @@ if minetest.get_modpath("vacuum") then
 end
 nautilus.have_air = minetest.settings:get_bool("nautilus_air", nautilus.have_air)
 nautilus.hull_deep_limit = minetest.settings:get_bool("nautilus_hull_deep_limit", true)
+nautilus.allow_put_light = minetest.settings:get_bool("nautilus_allow_put_light", true)
 
 local nautilus_attached = {}
 

--- a/init.lua
+++ b/init.lua
@@ -109,11 +109,14 @@ function nautilus.destroy(self, overload)
 
     if self.driver_name then
         driver = minetest.get_player_by_name(self.driver_name)
-        driver:set_detach()
-        driver:set_eye_offset({x = 0, y = 0, z = 0}, {x = 0, y = 0, z = 0})
+        -- prevent error when submarine of unlogged driver is destroied by preasure
+        if driver then
+            driver:set_detach()
+            driver:set_eye_offset({x = 0, y = 0, z = 0}, {x = 0, y = 0, z = 0})
+            -- player should stand again
+            player_api.set_animation(driver, "stand")
+        end
         player_api.player_attached[self.driver_name] = nil
-        -- player should stand again
-        player_api.set_animation(driver, "stand")
         self.driver_name = nil
     end
 

--- a/mod.conf
+++ b/mod.conf
@@ -1,6 +1,6 @@
 name = nautilus
 depends = mobkit,default,player_api,biofuel
-optional_depends = vacuum
+optional_depends = vacuum,moreores,technic,oak
 author = APercy
 description = Adds a craftable submarine
 title = Nautilus

--- a/nautilus_control.lua
+++ b/nautilus_control.lua
@@ -48,7 +48,7 @@ function nautilus.nautilus_control(self, dtime, hull_direction, longit_speed, ac
             end
             self.rudder_angle = 0
         end
-        if ctrl.up and ctrl.down and nautilus.nautilus_last_time_command > 0.3 and self.energy > 0 then
+        if ctrl.up and ctrl.down and nautilus.nautilus_last_time_command > 0.3 and self.energy > 0 and nautilus.allow_put_light then
             nautilus.nautilus_last_time_command = 0
             nautilus.put_light(self.object, self.driver_name)
             self.energy = self.energy - 0.005

--- a/nautilus_variants.lua
+++ b/nautilus_variants.lua
@@ -1,0 +1,163 @@
+
+-- wooden cabin
+minetest.register_craftitem("nautilus:cabin_wooden",{
+    description = "Wooden Cabin for Nautilus",
+    inventory_image = "nautilus_icon_cabin.png",
+})
+
+-- wooden boat
+minetest.register_tool("nautilus:boat_wooden", {
+    description = "Wooden Nautilus",
+    inventory_image = "nautilus_icon.png",
+    liquids_pointable = true,
+    stack_max = 1,
+    
+    hull_integrity = 50,
+    deep_limit = 25,
+    overload_drop = {"nautilus:engine", "default:bronze_ingot 3"},
+
+    on_place = nautilus.on_place,
+})
+
+-- boat
+minetest.override_item("nautilus:boat", {
+    hull_integrity = 75,
+    deep_limit = 40,
+    overload_drop = {"nautilus:engine", "default:steel_ingot 3","default:steelblock 3"},
+})
+
+-- carbon steel cabin
+minetest.register_craftitem("nautilus:cabin_carbon_steel",{
+    description = "Carbon Steel Cabin for Nautilus",
+    inventory_image = "nautilus_icon_cabin.png",
+})
+
+-- cabron teel boat
+minetest.register_tool("nautilus:boat_carbon_steel", {
+    description = "Carbon Steel Nautilus",
+    inventory_image = "nautilus_icon.png",
+    liquids_pointable = true,
+    stack_max = 1,
+    
+    hull_integrity = 100,
+    deep_limit = 300,
+    overload_drop = {"nautilus:engine", "technic:carbon_steel_ingot 3","technic:carbon_steel_block 3"},
+
+    on_place = nautilus.on_place,
+})
+
+-- stainless steel cabin
+minetest.register_craftitem("nautilus:cabin_stainless_steel",{
+    description = "Stainless Steel Cabin for Nautilus",
+    inventory_image = "nautilus_icon_cabin.png",
+})
+
+-- stainless steel boat
+minetest.register_tool("nautilus:boat_stainless_steel", {
+    description = "Stainless Steel Nautilus",
+    inventory_image = "nautilus_icon.png",
+    liquids_pointable = true,
+    stack_max = 1,
+    
+    hull_integrity = 200,
+    deep_limit = 900,
+    overload_drop = {"nautilus:engine", "technic:stainless_steel_ingot 3","technic:stainless_steel_block 3"},
+
+    on_place = nautilus.on_place,
+})
+
+-- mithril cabin
+minetest.register_craftitem("nautilus:cabin_mithril",{
+    description = "Mithril Cabin for Nautilus",
+    inventory_image = "nautilus_icon_cabin.png",
+})
+
+-- mithril boat
+minetest.register_tool("nautilus:boat_mithril", {
+    description = "Mithril Nautilus",
+    inventory_image = "nautilus_icon.png",
+    liquids_pointable = true,
+    stack_max = 1,
+    
+    hull_integrity = 400,
+    deep_limit = nil,
+    overload_drop = {"nautilus:engine", "moreores:mithril_ingot 3","moreores:mithril_block 3"},
+
+    on_place = nautilus.on_place,
+})
+
+if minetest.get_modpath("default") then
+    local wood_name = "group:wood"
+    if minetest.get_modpath("oak") then
+      wood_name = "oak:wood"
+    end
+    
+    minetest.register_craft({
+        output = "nautilus:boat_wooden",
+        recipe = {
+            {"",                "",               ""},
+            {"nautilus:engine", "nautilus:cabin_wooden", "nautilus:engine"},
+        }
+    })
+    minetest.register_craft({
+        output = "nautilus:cabin_wooden",
+        recipe = {
+            {"default:bronze_ingot", wood_name, "default:bronze_ingot"},
+            {wood_name,  "default:glass",      wood_name},
+            {"default:bronze_ingot", wood_name, "default:bronze_ingot"},
+        }
+    })
+end
+
+if minetest.get_modpath("technic") then
+    minetest.register_craft({
+        output = "nautilus:boat_carbon_steel",
+        recipe = {
+            {"",                "",               ""},
+            {"nautilus:engine", "nautilus:cabin_carbon_steel", "nautilus:engine"},
+        }
+    })
+    minetest.register_craft({
+        output = "nautilus:cabin_carbon_steel",
+        recipe = {
+            {"technic:carbon_steel_ingot", "technic:carbon_steel_block", "technic:carbon_steel_ingot"},
+            {"technic:carbon_steel_block",  "default:glass",      "technic:carbon_steel_block"},
+            {"technic:carbon_steel_ingot", "technic:carbon_steel_block", "technic:carbon_steel_ingot"},
+        }
+    })
+    
+    minetest.register_craft({
+        output = "nautilus:boat_stainless_steel",
+        recipe = {
+            {"",                "",               ""},
+            {"nautilus:engine", "nautilus:cabin_stainless_steel", "nautilus:engine"},
+        }
+    })
+    minetest.register_craft({
+        output = "nautilus:cabin_stainless_steel",
+        recipe = {
+            {"technic:stainless_steel_ingot", "technic:stainless_steel_block", "technic:stainless_steel_ingot"},
+            {"technic:stainless_steel_block",  "default:glass",      "technic:stainless_steel_block"},
+            {"technic:stainless_steel_ingot", "technic:stainless_steel_block", "technic:stainless_steel_ingot"},
+        }
+    })
+end
+
+if minetest.get_modpath("moreores") then
+    minetest.register_craft({
+        output = "nautilus:boat_mithril",
+        recipe = {
+            {"",                "",               ""},
+            {"nautilus:engine", "nautilus:cabin_mithril", "nautilus:engine"},
+        }
+    })
+    minetest.register_craft({
+        output = "nautilus:cabin_mithril",
+        recipe = {
+            {"moreores:mithril_ingot", "moreores:mithril_block", "moreores:mithril_ingot"},
+            {"moreores:mithril_block", "default:glass", "moreores:mithril_block"},
+            {"moreores:mithril_ingot", "moreores:mithril_block", "moreores:mithril_ingot"},
+        }
+    })
+end
+

--- a/settingtypes.txt
+++ b/settingtypes.txt
@@ -19,3 +19,6 @@ nautilus_reair_on_air (Reair on open) float 200 1
 # Air lost when cover is opened under water
 nautilus_open_air_lost (Lost of air when open) float 10 1
 
+# Enable hull overload by preasure
+nautilus_hull_deep_limit (Enable deep limit) bool true
+

--- a/settingtypes.txt
+++ b/settingtypes.txt
@@ -22,3 +22,6 @@ nautilus_open_air_lost (Lost of air when open) float 10 1
 # Enable hull overload by preasure
 nautilus_hull_deep_limit (Enable deep limit) bool true
 
+# Enable nautius variants
+nautilus_variants (Enable more nautilus variants) bool true
+

--- a/settingtypes.txt
+++ b/settingtypes.txt
@@ -25,3 +25,6 @@ nautilus_hull_deep_limit (Enable deep limit) bool true
 # Enable nautius variants
 nautilus_variants (Enable more nautilus variants) bool true
 
+# Enable nautius put light
+nautilus_allow_put_light (Enable nautilus light put) bool true
+


### PR DESCRIPTION
- adds hull integrity and pressure (deep) limit.
- more nautilus variants from different materials and different deep_limit and hull strength.
- Little change logic of drowning 
- setting can be used to disable deep_limit (for newly placed submarines), or to disable more submarine variants
- make light putting configurable (I am using this wielded light with water support https://github.com/minetest-mods/wielded_light/pull/10 , so I want to disable it for me)

Changes should not impact already placed submarines, should affect newly placed one.

Tips:
init.lua:363 -> better hull crushing sound can be added (maybe, change the formula for sound gain)
init.lua:376 -> better hull break sound can be added

Some sounds can be added too to the function open_cover.
